### PR TITLE
Update to the underlying APIs and fixes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 sacksName=coffeesacks
 sacksTitle=CoffeeSacks
-sacksVersion=1.99.7
+sacksVersion=1.99.8
 
 filterName=coffeefilter
-filterVersion=1.99.7
+filterVersion=1.99.8
 
 grinderName=coffeegrinder
-grinderVersion=1.99.7
+grinderVersion=1.99.8
 
-xmlresolverVersion=4.3.0
+xmlresolverVersion=4.4.0
 docbookVersion=5.2b12
 xslTNGversion=1.6.0
 

--- a/src/main/java/org/nineml/coffeesacks/GrammarFunction.java
+++ b/src/main/java/org/nineml/coffeesacks/GrammarFunction.java
@@ -54,7 +54,7 @@ import java.util.HashMap;
 
     @Override
     public SequenceType[] getArgumentTypes() {
-        return new SequenceType[]{SequenceType.SINGLE_STRING, SequenceType.OPTIONAL_NODE};
+        return new SequenceType[]{SequenceType.SINGLE_STRING, SequenceType.OPTIONAL_ITEM};
     }
 
     @Override


### PR DESCRIPTION
Updating to CoffeeGrinder 1.99.8 should fix the Windows issue.

Fixed the copy-and-paste error in the cs:grammar function.
