### PR TITLE
Workaround API incompabilities in  Saxon 10 and Saxon 11

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 sacksName=coffeesacks
 sacksTitle=CoffeeSacks
-sacksVersion=1.99.9
+sacksVersion=1.99.10
 
 filterName=coffeefilter
 filterVersion=1.99.8
@@ -10,8 +10,8 @@ grinderVersion=1.99.8
 
 xmlresolverVersion=4.4.0
 docbookVersion=5.2b12
-xslTNGversion=1.6.0
+xslTNGversion=1.7.0-11
 
-saxonVersion=10.8
+saxonVersion=11.3
 saxonGroup=net.sf.saxon
 saxonEdition=Saxon-HE

--- a/src/test/resources/grammar-string.xsl
+++ b/src/test/resources/grammar-string.xsl
@@ -23,7 +23,8 @@ month: "January"; "February"; "March"; "April";
 year: (digit, digit)?, digit, digit .
 </xsl:text>
   </xsl:variable>
-  <xsl:variable name="grammar" select="cs:grammar-string($ixml)"/>
+  <xsl:variable name="grammar" select="cs:grammar-string($ixml,
+                                       map { 'type': 'ixml' })"/>
   <doc>
     <xsl:sequence select="cs:parse-uri($grammar, 'date.inp')"/>
   </doc>

--- a/src/test/resources/grammar-uri.xsl
+++ b/src/test/resources/grammar-uri.xsl
@@ -11,7 +11,9 @@
 <xsl:mode on-no-match="shallow-copy"/>
 
 <xsl:template name="xsl:initial-template">
-  <xsl:variable name="grammar" select="cs:grammar-uri('date.ixml')"/>
+  <xsl:variable name="grammar" select="cs:grammar-uri('date.ixml',
+                                       map { 'type': 'ixml',
+                                             'encoding': 'UTF-8' })"/>
   <doc>
     <xsl:sequence select="cs:parse-uri($grammar, 'date.inp')"/>
   </doc>


### PR DESCRIPTION
The way `MapItem` is handled changed incompatibly between Saxon 10 and Saxon 11. In order to make it work with either verison of Saxon, the map handling has been rewritten to use reflection. 🙄 