### PR TITLE
Return error XML when grammar loading or parsing fails

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 sacksName=coffeesacks
 sacksTitle=CoffeeSacks
-sacksVersion=1.99.10
+sacksVersion=1.99.11
 
 filterName=coffeefilter
-filterVersion=1.99.8
+filterVersion=1.99.9
 
 grinderName=coffeegrinder
 grinderVersion=1.99.8

--- a/src/main/java/org/nineml/coffeesacks/XmlXdmWriter.java
+++ b/src/main/java/org/nineml/coffeesacks/XmlXdmWriter.java
@@ -1,0 +1,271 @@
+package org.nineml.coffeesacks;
+
+import net.sf.saxon.s9api.*;
+import org.nineml.coffeefilter.util.XmlWriter;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+
+import java.util.Map;
+
+public class XmlXdmWriter extends XmlWriter {
+    private final BuildingContentHandler handler;
+
+    public XmlXdmWriter(Processor processor) {
+        DocumentBuilder builder = processor.newDocumentBuilder();
+        try {
+            this.handler = builder.newBuildingContentHandler();
+        } catch (SaxonApiException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public XdmNode getDocument() {
+        try {
+            return handler.getDocumentNode();
+        } catch (SaxonApiException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public void addNode(XdmNode node) {
+        if (node.getNodeKind() == XdmNodeKind.DOCUMENT) {
+            XdmSequenceIterator<XdmNode> iter = node.axisIterator(Axis.CHILD);
+            while (iter.hasNext()) {
+                addNode(iter.next());
+            }
+            return;
+        }
+
+        if (node.getNodeKind() == XdmNodeKind.ELEMENT) {
+            Map<String,String> inscope = this.getInScopeNamespaces();
+            XdmSequenceIterator<XdmNode> iter = node.axisIterator(Axis.NAMESPACE);
+            while (iter.hasNext()) {
+                XdmNode ns = iter.next();
+                String prefix = ns.getNodeName().getLocalName();
+                String uri = ns.getStringValue();
+                if (!uri.equals(inscope.getOrDefault(prefix, null))) {
+                    declareNamespace(prefix, uri);
+                }
+            }
+            startElement(node.getNodeName().toString());
+            iter = node.axisIterator(Axis.ATTRIBUTE);
+            while (iter.hasNext()) {
+                XdmNode attr = iter.next();
+                addAttribute(attr.getNodeName().toString(), attr.getStringValue());
+            }
+            iter = node.axisIterator(Axis.CHILD);
+            while (iter.hasNext()) {
+                addNode(iter.next());
+            }
+            endElement();
+            return;
+        }
+
+        if (node.getNodeKind() == XdmNodeKind.TEXT) {
+            text(node.getStringValue());
+            return;
+        }
+
+        if (node.getNodeKind() == XdmNodeKind.COMMENT) {
+            comment(node.getStringValue());
+            return;
+        }
+
+        if (node.getNodeKind() == XdmNodeKind.PROCESSING_INSTRUCTION) {
+            processingInstruction(node.getNodeName().getLocalName(), node.getStringValue());
+            return;
+        }
+
+        throw new IllegalStateException("Unexpected element kind"); // This can't happen
+    }
+
+    @Override
+    protected void writeStartDocument() {
+        try {
+            handler.startDocument();
+        } catch (SAXException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    protected void writeEndDocument() {
+        try {
+            handler.endDocument();
+        } catch (SAXException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    protected void startPrefixMapping(String prefix, String uri) {
+        try {
+            handler.startPrefixMapping(prefix, uri);
+        } catch (SAXException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    protected void endPrefixMapping(String prefix, String uri) {
+        try {
+            handler.endPrefixMapping(prefix);
+        } catch (SAXException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    protected void writeStartElement(XmlQName tag, Map<XmlQName, String> attributes) {
+        try {
+            handler.startElement(tag.namespaceURI, tag.localName, tag.toString(), new SaxAttributes(attributes));
+        } catch (SAXException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    protected void writeEndElement(XmlQName tag) {
+        try {
+            handler.endElement(tag.namespaceURI, tag.localName, tag.toString());
+        } catch (SAXException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    protected void writeText(String text) {
+        try {
+            handler.characters(text.toCharArray(), 0, text.length());
+        } catch (SAXException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    protected void writeComment(String comment) {
+        /// handler doesn't have a comment method? WAT?
+    }
+
+    @Override
+    protected void writeProcessingInstruction(String name, String data) {
+        try {
+            handler.processingInstruction(name, data);
+        } catch (SAXException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private static class SaxAttributes implements Attributes {
+        private final XmlQName[] names;
+        private final String[] values;
+
+        public SaxAttributes(Map<XmlQName,String> attributes) {
+            names = new XmlQName[attributes.size()];
+            values = new String[attributes.size()];
+            int pos = 0;
+            for (XmlQName name : attributes.keySet()) {
+                names[pos] = name;
+                values[pos] = attributes.get(name);
+                pos++;
+            }
+        }
+
+        @Override
+        public int getLength() {
+            return names.length;
+        }
+
+        @Override
+        public String getURI(int index) {
+            if (index <= names.length) {
+                return names[index].namespaceURI;
+            }
+            return null;
+        }
+
+        @Override
+        public String getLocalName(int index) {
+            if (index <= names.length) {
+                return names[index].localName;
+            }
+            return null;
+        }
+
+        @Override
+        public String getQName(int index) {
+            if (index <= names.length) {
+                return names[index].toString();
+            }
+            return null;
+        }
+
+        @Override
+        public String getType(int index) {
+            if (index <= names.length) {
+                return "CDATA";
+            }
+            return null;
+        }
+
+        @Override
+        public String getValue(int index) {
+            if (index <= values.length) {
+                return values[index];
+            }
+            return null;
+        }
+
+        @Override
+        public int getIndex(String uri, String localName) {
+            for (int pos = 0; pos < names.length; pos++) {
+                if (names[pos].namespaceURI.equals(uri) && names[pos].localName.equals(localName)) {
+                    return pos;
+                }
+            }
+            return -1;
+        }
+
+        @Override
+        public int getIndex(String qName) {
+            for (int pos = 0; pos < names.length; pos++) {
+                if (names[pos].toString().equals(qName)) {
+                    return pos;
+                }
+            }
+            return -1;
+        }
+
+        @Override
+        public String getType(String uri, String localName) {
+            if (getIndex(uri, localName) >= 0) {
+                return "CDATA";
+            }
+            return null;
+        }
+
+        @Override
+        public String getType(String qName) {
+            if (getIndex(qName) >= 0) {
+                return "CDATA";
+            }
+            return null;
+        }
+
+        @Override
+        public String getValue(String uri, String localName) {
+            int pos = getIndex(uri, localName);
+            if (pos >= 0) {
+                return values[pos];
+            }
+            return null;
+        }
+
+        @Override
+        public String getValue(String qName) {
+            int pos = getIndex(qName);
+            if (pos >= 0) {
+                return values[pos];
+            }
+            return null;
+        }
+    }
+}

--- a/src/test/resources/bad-grammar.ixml
+++ b/src/test/resources/bad-grammar.ixml
@@ -1,0 +1,11 @@
+date: s?, day, -s, month, (-s, year)? .
+
+this is an error
+
+-s: -" "+ .
+day: digit, digit? .
+-digit: "0"; "1"; "2"; "3"; "4"; "5"; "6"; "7"; "8"; "9".
+month: "January"; "February"; "March"; "April";
+       "May"; "June"; "July"; "August";
+       "September"; "October"; "November"; "December".
+year: (digit, digit)?, digit, digit .

--- a/src/test/resources/bad-grammar.xsl
+++ b/src/test/resources/bad-grammar.xsl
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cs="http://nineml.com/ns/coffeesacks"
+                xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                exclude-result-prefixes="#all"
+                expand-text="yes"
+                version="3.0">
+
+<xsl:output method="xml" encoding="utf-8" indent="no"/>
+
+<xsl:mode on-no-match="shallow-copy"/>
+
+<xsl:template name="xsl:initial-template">
+  <xsl:variable name="grammar" select="cs:grammar-uri('bad-grammar.ixml')"/>
+
+  <doc>
+    <xsl:sequence select="cs:parse-uri($grammar, 'date.inp')"/>
+  </doc>
+<!--
+  <xsl:variable name="map" 
+                select="cs:parse-uri($grammar, 'date.inp',
+                                     map { 'format': 'json' })"/>
+  <xsl:variable name="date" select="$map?date"/>
+-->
+</xsl:template>
+
+</xsl:stylesheet>

--- a/src/test/resources/not-grammar.xsl
+++ b/src/test/resources/not-grammar.xsl
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cs="http://nineml.com/ns/coffeesacks"
+                xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                exclude-result-prefixes="#all"
+                expand-text="yes"
+                version="3.0">
+
+<xsl:output method="xml" encoding="utf-8" indent="no"/>
+
+<xsl:mode on-no-match="shallow-copy"/>
+
+<xsl:template name="xsl:initial-template">
+  <xsl:variable name="not-grammar"><not-a-grammar/></xsl:variable>
+  <doc>
+    <xsl:sequence select="cs:parse-uri($not-grammar, 'date.inp', map{'format': 'xml'})"/>
+  </doc>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/src/test/resources/not-xml.xsl
+++ b/src/test/resources/not-xml.xsl
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:cs="http://nineml.com/ns/coffeesacks"
+                xmlns:map="http://www.w3.org/2005/xpath-functions/map"
+                exclude-result-prefixes="#all"
+                expand-text="yes"
+                version="3.0">
+
+<xsl:output method="xml" encoding="utf-8" indent="no"/>
+
+<xsl:mode on-no-match="shallow-copy"/>
+
+<xsl:template name="xsl:initial-template">
+  <xsl:variable name="grammar" select="cs:grammar-uri('bad-grammar.ixml')"/>
+
+  <doc>
+    <xsl:sequence select="cs:parse-uri($grammar, 'date.inp')"/>
+  </doc>
+<!--
+  <xsl:variable name="map" 
+                select="cs:parse-uri($grammar, 'date.inp',
+                                     map { 'format': 'json' })"/>
+  <xsl:variable name="date" select="$map?date"/>
+-->
+</xsl:template>
+
+</xsl:stylesheet>

--- a/src/website/xml/coffeesacks.xml
+++ b/src/website/xml/coffeesacks.xml
@@ -86,13 +86,36 @@ grammar and return the result:</para>
 
 </chapter>
 
-<chapter>
-<title>cs:grammar-string</title>
+<chapter xml:id="loading-grammars">
+<title>Loading grammars</title>
 
 <para>Before it can be used, a grammar must be loaded. You can load Invisible XML
 grammars in either the text or XML syntax. You can also load grammars in the
 <link xlink:href="https://coffeegrinder.nineml.org/">CoffeeGrinder</link> compiled
 format.</para>
+
+<para>The grammar loading functions return an XML document. If the
+function succeeds, this will be a compiled representation of the
+grammar. It is not very useful except as the grammar input to one of
+<link linkend="parsing-inputs">the parsing functions</link>.
+(If you’re interested in a useful XML
+representation of an Invisible XML grammar, parse the grammar with the
+Invisible XML grammar.)</para>
+
+<para>If the grammar could not be loaded, what will be returned will
+be a <tag>cs:error</tag> document (where the <code>cs</code> prefix is
+bound to
+<uri type="xmlnamespace">https://ninenl.org/ns/coffeesacks/error</uri>).
+This document will have a <tag class="attribute">code</tag> attribute
+that attempts to identify the error. The contents of the error
+document will further describe the error.</para>
+
+<para>The only code returned by the grammar functions is
+<code>badgrammar</code>, indicating that the attempt to parse the grammar
+failed.</para>
+
+<section>
+<title>cs:grammar-string</title>
 
 <para>This function takes a string in the Invisible XML grammar format and parses
 it into a grammar. You can load the XML grammar formats directly as XML. You can load
@@ -143,15 +166,12 @@ accepted is <code>ixml</code>, the text format.</para>
 </listitem>
 </varlistentry>
 </variablelist>
-</chapter>
+</section>
 
-<chapter>
+<section>
 <title>cs:grammar-uri</title>
 
-<para>Before it can be used, a grammar must be loaded. You can load Invisible XML
-grammars in either the text or XML syntax. You can also load grammars in the
-<link xlink:href="https://coffeegrinder.nineml.org/">CoffeeGrinder</link> compiled
-format.</para>
+<para>This function loads a grammar from a URI.</para>
 
 <funcsynopsis>
 <funcprototype>
@@ -241,18 +261,51 @@ bytes of the file to identify the grammar which is usually sufficient.</para>
 </listitem>
 </varlistentry>
 </variablelist>
+</section>
 </chapter>
 
-<chapter>
+<chapter xml:id="parsing-inputs">
+<title>Parsing inputs</title>
+
+<para>The parsing functions attempts to parse the input string with
+the grammar provided. The result will be an XML document (or a map)
+that is either the parsed result or a document that specifies that an
+error occurred.</para>
+
+<para>The grammar provided must be in XML format. This can be obtained
+with the <link linkend="loading-grammars">grammar loading
+functions</link> or, in the case of XML format grammars, through any
+convenient means.</para>
+
+<para>The parsing functions return an XML document (or a map). If the
+parse is successful, this will be a representation of the result of
+parsing the input with the grammar.</para>
+
+<para>If the parse is unsuccessful, a top-level <tag>ixml:state</tag>
+attribute (or property) with the value “<code>fail</code>” indicates
+that the parse did not succeed. The rest of the document will contain
+information that is designed to help you identify the error.</para>
+
+<para>If the grammar could not be used, what will be returned will
+be a <tag>cs:error</tag> document (where the <code>cs</code> prefix is
+bound to
+<uri type="xmlnamespace">https://ninenl.org/ns/coffeesacks/error</uri>).
+This document will have a <tag class="attribute">code</tag> attribute
+that attempts to identify the error. The contents of the error
+document will further describe the error.</para>
+
+<para>(If a JSON result was requested, the error document will have a
+<code>cs:error</code> property with the value of the code.)</para>
+
+<para>The possible codes are <code>notgrammar</code>, if the input
+grammar was not a recognized XML representation of an Invisible XML
+grammar, or <code>notxml</code>, if the input grammar was not
+XML.</para>
+
+<section>
 <title>cs:parse-string</title>
 
-<para>Attempts to parse the input string
-the grammar provided. The result will be an XML document that is either the parsed
-result or a document that specifies that an error occurred.</para>
-
-<para>The grammar provided must be in XML format. This can be obtained with the
-<function>cs:grammar-uri</function> function or, in the case of XML format grammars,
-through any convenient means.</para>
+<para>Parses an input string against a grammar.</para>
 
 <funcsynopsis>
 <funcprototype>
@@ -342,18 +395,13 @@ of the grammar and the underlying Invisible XML parser object.</para>
 </listitem>
 </varlistentry>
 </variablelist>
-</chapter>
+</section>
 
-<chapter>
+<section>
 <title>cs:parse-uri</title>
 
 <para>Loads the document at the specified URI and attempts to parse it with
-the grammar provided. The result will be an XML document that is either the parsed
-result or a document that specifies that an error occurred.</para>
-
-<para>The grammar provided must be in XML format. This can be obtained with the
-<function>cs:grammar-uri</function> function or, in the case of XML format grammars,
-through any convenient means.</para>
+the grammar provided.</para>
 
 <funcsynopsis>
 <funcprototype>
@@ -450,6 +498,7 @@ of the grammar and the underlying Invisible XML parser object.</para>
 </listitem>
 </varlistentry>
 </variablelist>
+</section>
 </chapter>
 
 <chapter>


### PR DESCRIPTION
Fix #28 

Throwing an exception for bad grammars or bad parses is pretty hostile in an XSLT environment. Instead, error XML (or JSON) is returned. 