### PR TITLE
Bump versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ import com.nwalsh.gradle.saxon.SaxonXsltTask
 import com.nwalsh.gradle.relaxng.validate.RelaxNGValidateTask
 import com.nwalsh.gradle.docker.DockerContainer
 
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"
+
 repositories {
   mavenLocal()
   mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,16 @@
 sacksName=coffeesacks
 sacksTitle=CoffeeSacks
-sacksVersion=1.99.12
+sacksVersion=1.99.13
 
 filterName=coffeefilter
-filterVersion=1.99.9
+filterVersion=1.99.12
 
 grinderName=coffeegrinder
-grinderVersion=1.99.8
+grinderVersion=1.99.12
 
-xmlresolverVersion=4.4.0
-docbookVersion=5.2b12
-xslTNGversion=1.7.0-11
+xmlresolverVersion=4.5.1
+docbookVersion=5.2CR2
+xslTNGversion=1.8.1
 
 saxonVersion=11.3
 saxonGroup=net.sf.saxon


### PR DESCRIPTION
Update to a `CoffeeGrinder` version that has "fixed" the problem with marks and the GLL parser.