### PR TITLE
Make sure the currently selected alternative is always first

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
 sacksName=coffeesacks
 sacksTitle=CoffeeSacks
-sacksVersion=2.1.0
+sacksVersion=2.2.0
 
 filterName=coffeefilter
-filterVersion=2.1.0
+filterVersion=2.2.0
 
 grinderName=coffeegrinder
-grinderVersion=2.1.0
+grinderVersion=2.2.0
 
 xmlresolverVersion=5.1.2
 docbookVersion=5.2CR5

--- a/src/main/java/org/nineml/coffeesacks/AlternativeEventBuilder.java
+++ b/src/main/java/org/nineml/coffeesacks/AlternativeEventBuilder.java
@@ -71,11 +71,15 @@ public class AlternativeEventBuilder extends EventBuilder {
 
                 // I checked the return type when I loaded the function, so I think this is safe
                 long value = ((Int64Value) result.head()).longValue();
-                if (value != 0) {
+                if (value != 0 && value != 1) { // 1 is the same as 0
                     if (value < 0 || value > alternatives.size()) {
                         throw new IllegalArgumentException("Value out of range from choose-alternatives function");
                     }
-                    return ((int) value) - 1;
+
+                    value--; // convert back to 0-based index
+
+                    // Map the number back to the "right" number in the un-reordered list
+                    return ((int) (value <= selected ? value - 1 : value));
                 }
             } catch (XPathException err) {
                 throw new RuntimeException(err);

--- a/src/main/java/org/nineml/coffeesacks/AlternativeEventBuilder.java
+++ b/src/main/java/org/nineml/coffeesacks/AlternativeEventBuilder.java
@@ -41,10 +41,26 @@ public class AlternativeEventBuilder extends EventBuilder {
     }
 
     @Override
-    public int startAlternative(ForestNode tree, List<RuleChoice> alternatives) {
-        int selected = super.startAlternative(tree, alternatives);
+    public int startAlternative(ForestNode tree, List<RuleChoice> ruleAlternatives) {
+        int selected = super.startAlternative(tree, ruleAlternatives);
 
         if (chooseAlternatives != null) {
+            // Reorder the alternatives so that the selected choice is always first
+            final List<RuleChoice> alternatives;
+            if (selected == 0) {
+                alternatives = ruleAlternatives;
+            } else {
+                alternatives = new ArrayList<>();
+                alternatives.add(ruleAlternatives.get(selected));
+                int count = 0;
+                for (RuleChoice alt : ruleAlternatives) {
+                    if (count != selected) {
+                        alternatives.add(alt);
+                    }
+                    count++;
+                }
+            }
+
             try {
                 List<XdmNode> xmlAlternatives = xmlAlternatives(tree, alternatives);
                 ArrayList<NodeInfo> nodeAlternatives = new ArrayList<>();

--- a/src/test/java/org/nineml/coffeesacks/AlternativeTests.java
+++ b/src/test/java/org/nineml/coffeesacks/AlternativeTests.java
@@ -1,0 +1,56 @@
+package org.nineml.coffeesacks;
+
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.Arrays;
+import java.util.List;
+
+// Just check that the algorithm for computing alternatives works
+public class AlternativeTests {
+    private int makeSelection(int value, int selected) {
+        if (value != 0 && value != 1) { // 1 is the same as 0
+            value--; // convert back to 0-based index
+            // Map the number back to the "right" number in the un-reordered list
+            return ((int) (value <= selected ? value - 1 : value));
+        }
+        return selected;
+    }
+
+    @Test
+    public void select0() {
+        List<Integer> list = Arrays.asList(2, 0, 1, 3, 4);
+        Assertions.assertEquals(2, makeSelection(0, 2));
+    }
+
+    @Test
+    public void select1() {
+        List<Integer> list = Arrays.asList(2, 0, 1, 3, 4);
+        Assertions.assertEquals(2, makeSelection(1, 2));
+    }
+
+    @Test
+    public void select2() {
+        List<Integer> list = Arrays.asList(2, 0, 1, 3, 4);
+        Assertions.assertEquals(0, makeSelection(2, 2));
+    }
+
+    @Test
+    public void select3() {
+        List<Integer> list = Arrays.asList(2, 0, 1, 3, 4);
+        Assertions.assertEquals(1, makeSelection(3, 2));
+    }
+
+    @Test
+    public void select4() {
+        List<Integer> list = Arrays.asList(2, 0, 1, 3, 4);
+        Assertions.assertEquals(3, makeSelection(4, 2));
+    }
+
+    @Test
+    public void select5() {
+        List<Integer> list = Arrays.asList(2, 0, 1, 3, 4);
+        Assertions.assertEquals(4, makeSelection(5, 0));
+    }
+
+}

--- a/src/website/xml/alternatives.xml
+++ b/src/website/xml/alternatives.xml
@@ -21,6 +21,14 @@ examine the alternatives and select one. You can supply a
 must be a function that takes a single argument, a list of elements,
 and returns an integer.</para>
 
+<note>
+<para>More than one approach to resolving ambiguity may be applied. For example,
+CoffeeFilter supports a “priority” pragma that lets the grammar author identify
+a preferred resolution. When the <code>choose-alternative</code> function is called,
+the first element in the list is always the currently selected alternative, if some
+previous process has been applied.</para>
+</note>
+
 <para>The function must return an integer between 0 and the number of
 alternatives provided. The number is the alternative selected. A value
 of 0 indicates that the function did not select an alternative. The

--- a/src/website/xml/changelog.xml
+++ b/src/website/xml/changelog.xml
@@ -7,6 +7,15 @@
 
 <revhistory>
 <revision>
+  <revnumber>2.2.0</revnumber>
+  <date>2023-05-06</date>
+  <revdescription>
+    <para>Updated the way the <link linkend="choose-alternative">choose alternative</link>
+    function is called to assure that the first element in the list is always the
+    current “best” choice.</para>
+  </revdescription>
+</revision>
+<revision>
   <revnumber>2.1.0</revnumber>
   <date>2023-04-23</date>
   <revdescription>


### PR DESCRIPTION
When choosing between alternatives, a previous selection may already have been made (for example, by a priority pragma). In this release, the first alternative passed to the choose alternatives function will always be the currently selected alternative.